### PR TITLE
Correctly dispose objects to release HTTP connections

### DIFF
--- a/src/CloudFlare.NET/HttpClientDnsRecordExtensions.cs
+++ b/src/CloudFlare.NET/HttpClientDnsRecordExtensions.cs
@@ -17,31 +17,17 @@
         /// Gets the zones for the account specified by the <paramref name="auth"/> details.
         /// </summary>
         /// <seealso href="https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records"/>
-        public static async Task<IReadOnlyList<DnsRecord>> GetDnsRecordsAsync(
+        public static Task<IReadOnlyList<DnsRecord>> GetDnsRecordsAsync(
             this HttpClient client,
             IdentifierTag zoneId,
             CancellationToken cancellationToken,
             CloudFlareAuth auth)
         {
-            if (client == null)
-                throw new ArgumentNullException(nameof(client));
             if (zoneId == null)
                 throw new ArgumentNullException(nameof(zoneId));
-            if (auth == null)
-                throw new ArgumentNullException(nameof(auth));
 
             Uri uri = new Uri(CloudFlareConstants.BaseUri, $"zones/{zoneId}/dns_records");
-            var request = new HttpRequestMessage(HttpMethod.Get, uri);
-            request.AddAuth(auth);
-
-            HttpResponseMessage response =
-                await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-                    .ConfigureAwait(false);
-
-            return (await response
-                .GetResultAsync<IReadOnlyList<DnsRecord>>(cancellationToken)
-                .ConfigureAwait(false))
-                .Result;
+            return client.GetAsync<IReadOnlyList<DnsRecord>>(uri, auth, cancellationToken);
         }
     }
 }

--- a/src/CloudFlare.NET/HttpClientZoneExtensions.cs
+++ b/src/CloudFlare.NET/HttpClientZoneExtensions.cs
@@ -17,65 +17,36 @@
         /// Gets the zones for the account specified by the <paramref name="auth"/> details.
         /// </summary>
         /// <seealso href="https://api.cloudflare.com/#zone-list-zones"/>
-        public static async Task<IReadOnlyList<Zone>> GetZonesAsync(
+        public static Task<IReadOnlyList<Zone>> GetZonesAsync(
             this HttpClient client,
             CancellationToken cancellationToken,
             CloudFlareAuth auth,
             PagedZoneParameters parameters = null)
         {
-            if (client == null)
-                throw new ArgumentNullException(nameof(client));
-            if (auth == null)
-                throw new ArgumentNullException(nameof(auth));
-
             Uri uri = new Uri(CloudFlareConstants.BaseUri, "zones");
             if (parameters != null)
             {
                 uri = new UriBuilder(uri) { Query = parameters.ToQuery() }.Uri;
             }
 
-            var request = new HttpRequestMessage(HttpMethod.Get, uri);
-            request.AddAuth(auth);
-
-            HttpResponseMessage response =
-                await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-                    .ConfigureAwait(false);
-
-            return (await response
-                .GetResultAsync<IReadOnlyList<Zone>>(cancellationToken)
-                .ConfigureAwait(false))
-                .Result;
+            return client.GetAsync<IReadOnlyList<Zone>>(uri, auth, cancellationToken);
         }
 
         /// <summary>
         /// Gets the zones for the account specified by the <paramref name="auth"/> details.
         /// </summary>
         /// <seealso href="https://api.cloudflare.com/#zone-zone-details"/>
-        public static async Task<Zone> GetZoneAsync(
+        public static Task<Zone> GetZoneAsync(
             this HttpClient client,
             IdentifierTag zoneId,
             CancellationToken cancellationToken,
             CloudFlareAuth auth)
         {
-            if (client == null)
-                throw new ArgumentNullException(nameof(client));
             if (zoneId == null)
                 throw new ArgumentNullException(nameof(zoneId));
-            if (auth == null)
-                throw new ArgumentNullException(nameof(auth));
 
             Uri uri = new Uri(CloudFlareConstants.BaseUri, $"zones/{zoneId}");
-            var request = new HttpRequestMessage(HttpMethod.Get, uri);
-            request.AddAuth(auth);
-
-            HttpResponseMessage response =
-                await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-                    .ConfigureAwait(false);
-
-            return (await response
-                .GetResultAsync<Zone>(cancellationToken)
-                .ConfigureAwait(false))
-                .Result;
+            return client.GetAsync<Zone>(uri, auth, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
During live usage I discovered the maximum HTTP connections (defaults to 2) were excused, as a result the application hung on the third request. The fix is to correctly dispose of the HTTP request/response objects, something I thought unnecessary for HttpClient.

:+1: to @robcthegeek, who resolutely disposed of the request/response objects when we worked together on another project :smile:
