### PR TITLE
Added support for paged results

### DIFF
--- a/src/CloudFlare.NET.Yaml/CloudFlare.NET.Yaml.csproj
+++ b/src/CloudFlare.NET.Yaml/CloudFlare.NET.Yaml.csproj
@@ -42,7 +42,7 @@
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.2\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/CloudFlare.NET.Yaml/CloudFlare.NET.Yaml.csproj
+++ b/src/CloudFlare.NET.Yaml/CloudFlare.NET.Yaml.csproj
@@ -94,7 +94,8 @@
     <Analyzer Include="..\packages\AsyncFixer.1.0.0.0\tools\analyzers\System.Composition.Hosting.dll" />
     <Analyzer Include="..\packages\AsyncFixer.1.0.0.0\tools\analyzers\System.Composition.Runtime.dll" />
     <Analyzer Include="..\packages\AsyncFixer.1.0.0.0\tools\analyzers\System.Composition.TypedParts.dll" />
-    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0-beta008\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0-beta009\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0-beta009\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/CloudFlare.NET.Yaml/CloudFlare.NET.Yaml.nuspec
+++ b/src/CloudFlare.NET.Yaml/CloudFlare.NET.Yaml.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>0.0.5</version>
+    <version>0.1.0</version>
     <title>$title$</title>
     <authors>James Skimming</authors>
     <owners>James Skimming</owners>
@@ -12,7 +12,7 @@
     <description>$description$</description>
     <tags>CloudFlare YAML API Client</tags>
     <dependencies>
-      <dependency id="CloudFlare.NET" version="0.0.5" />
+      <dependency id="CloudFlare.NET" version="0.1.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/CloudFlare.NET.Yaml/CloudFlareClientExtensions.cs
+++ b/src/CloudFlare.NET.Yaml/CloudFlareClientExtensions.cs
@@ -37,12 +37,12 @@
                 throw new ArgumentNullException(nameof(zoneId));
 
             Task<Zone> zoneTask = client.GetZoneAsync(zoneId, cancellationToken, auth);
-            Task<IReadOnlyList<DnsRecord>> dnsRecordsTask =
+            Task<CloudFlareResponse<IReadOnlyList<DnsRecord>>> dnsRecordsTask =
                 client.GetDnsRecordsAsync(zoneId, cancellationToken, auth: auth);
 
             await Task.WhenAll(zoneTask, dnsRecordsTask).ConfigureAwait(false);
 
-            return new ZoneData(zoneTask.Result, dnsRecordsTask.Result);
+            return new ZoneData(zoneTask.Result, dnsRecordsTask.Result.Result);
         }
     }
 }

--- a/src/CloudFlare.NET.Yaml/CloudFlareClientExtensions.cs
+++ b/src/CloudFlare.NET.Yaml/CloudFlareClientExtensions.cs
@@ -37,7 +37,8 @@
                 throw new ArgumentNullException(nameof(zoneId));
 
             Task<Zone> zoneTask = client.GetZoneAsync(zoneId, cancellationToken, auth);
-            Task<IReadOnlyList<DnsRecord>> dnsRecordsTask = client.GetDnsRecordsAsync(zoneId, cancellationToken, auth);
+            Task<IReadOnlyList<DnsRecord>> dnsRecordsTask =
+                client.GetDnsRecordsAsync(zoneId, cancellationToken, auth: auth);
 
             await Task.WhenAll(zoneTask, dnsRecordsTask).ConfigureAwait(false);
 

--- a/src/CloudFlare.NET.Yaml/CloudFlareClientExtensions.cs
+++ b/src/CloudFlare.NET.Yaml/CloudFlareClientExtensions.cs
@@ -37,12 +37,12 @@
                 throw new ArgumentNullException(nameof(zoneId));
 
             Task<Zone> zoneTask = client.GetZoneAsync(zoneId, cancellationToken, auth);
-            Task<CloudFlareResponse<IReadOnlyList<DnsRecord>>> dnsRecordsTask =
-                client.GetDnsRecordsAsync(zoneId, cancellationToken, auth: auth);
+            Task<IEnumerable<DnsRecord>> dnsRecordsTask =
+                client.GetAllDnsRecordsAsync(zoneId, cancellationToken, auth: auth);
 
             await Task.WhenAll(zoneTask, dnsRecordsTask).ConfigureAwait(false);
 
-            return new ZoneData(zoneTask.Result, dnsRecordsTask.Result.Result);
+            return new ZoneData(zoneTask.Result, dnsRecordsTask.Result.ToArray());
         }
     }
 }

--- a/src/CloudFlare.NET.Yaml/Properties/AssemblyInfo.cs
+++ b/src/CloudFlare.NET.Yaml/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.5.0")]
-[assembly: AssemblyFileVersion("0.0.5.0")]
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]

--- a/src/CloudFlare.NET.Yaml/packages.config
+++ b/src/CloudFlare.NET.Yaml/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Bcl" version="1.1.9" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable45-net45+win8+wp8+wpa81" />
-  <package id="Newtonsoft.Json" version="6.0.2" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="StyleCop.Analyzers" version="1.0.0-beta008" targetFramework="portable45-net45+win8+wp8+wpa81" developmentDependency="true" />
   <package id="YamlDotNet" version="3.7.0" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>

--- a/src/CloudFlare.NET.Yaml/packages.config
+++ b/src/CloudFlare.NET.Yaml/packages.config
@@ -6,6 +6,6 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable45-net45+win8+wp8+wpa81" />
-  <package id="StyleCop.Analyzers" version="1.0.0-beta008" targetFramework="portable45-net45+win8+wp8+wpa81" developmentDependency="true" />
+  <package id="StyleCop.Analyzers" version="1.0.0-beta009" targetFramework="portable45-net45+win8+wp8+wpa81" developmentDependency="true" />
   <package id="YamlDotNet" version="3.7.0" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>

--- a/src/CloudFlare.NET/CloudFlare.NET.csproj
+++ b/src/CloudFlare.NET/CloudFlare.NET.csproj
@@ -42,7 +42,7 @@
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.2\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/CloudFlare.NET/CloudFlare.NET.csproj
+++ b/src/CloudFlare.NET/CloudFlare.NET.csproj
@@ -84,6 +84,8 @@
     <Compile Include="IIdentifier.cs" />
     <Compile Include="IModified.cs" />
     <Compile Include="IZoneClient.cs" />
+    <Compile Include="PagedDnsRecordOrderFieldTypes.cs" />
+    <Compile Include="PagedDnsRecordParameters.cs" />
     <Compile Include="PagedParameters.cs" />
     <Compile Include="PagedParametersExtensions.cs" />
     <Compile Include="PagedParametersMatchType.cs" />

--- a/src/CloudFlare.NET/CloudFlare.NET.csproj
+++ b/src/CloudFlare.NET/CloudFlare.NET.csproj
@@ -103,7 +103,15 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0-beta008\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+    <Analyzer Include="..\packages\AsyncFixer.1.0.0.0\tools\analyzers\AsyncFixer.dll" />
+    <Analyzer Include="..\packages\AsyncFixer.1.0.0.0\tools\analyzers\RoslynUtilities.dll" />
+    <Analyzer Include="..\packages\AsyncFixer.1.0.0.0\tools\analyzers\System.Composition.AttributedModel.dll" />
+    <Analyzer Include="..\packages\AsyncFixer.1.0.0.0\tools\analyzers\System.Composition.Convention.dll" />
+    <Analyzer Include="..\packages\AsyncFixer.1.0.0.0\tools\analyzers\System.Composition.Hosting.dll" />
+    <Analyzer Include="..\packages\AsyncFixer.1.0.0.0\tools\analyzers\System.Composition.Runtime.dll" />
+    <Analyzer Include="..\packages\AsyncFixer.1.0.0.0\tools\analyzers\System.Composition.TypedParts.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0-beta009\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0-beta009\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/CloudFlare.NET/CloudFlare.NET.nuspec
+++ b/src/CloudFlare.NET/CloudFlare.NET.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>0.0.5</version>
+    <version>0.1.0</version>
     <title>$title$</title>
     <authors>James Skimming</authors>
     <owners>James Skimming</owners>

--- a/src/CloudFlare.NET/CloudFlareClient.cs
+++ b/src/CloudFlare.NET/CloudFlareClient.cs
@@ -162,9 +162,10 @@
         public Task<IReadOnlyList<DnsRecord>> GetDnsRecordsAsync(
             IdentifierTag zoneId,
             CancellationToken cancellationToken,
+            PagedDnsRecordParameters parameters = null,
             CloudFlareAuth auth = null)
         {
-            return _client.GetDnsRecordsAsync(zoneId, cancellationToken, auth ?? _auth);
+            return _client.GetDnsRecordsAsync(zoneId, cancellationToken, auth ?? _auth, parameters);
         }
     }
 }

--- a/src/CloudFlare.NET/CloudFlareClient.cs
+++ b/src/CloudFlare.NET/CloudFlareClient.cs
@@ -159,7 +159,7 @@
         }
 
         /// <inheritdoc/>
-        public Task<IReadOnlyList<DnsRecord>> GetDnsRecordsAsync(
+        public Task<CloudFlareResponse<IReadOnlyList<DnsRecord>>> GetDnsRecordsAsync(
             IdentifierTag zoneId,
             CancellationToken cancellationToken,
             PagedDnsRecordParameters parameters = null,

--- a/src/CloudFlare.NET/CloudFlareClient.cs
+++ b/src/CloudFlare.NET/CloudFlareClient.cs
@@ -141,7 +141,7 @@
         }
 
         /// <inheritdoc/>
-        public Task<IReadOnlyList<Zone>> GetZonesAsync(
+        public Task<CloudFlareResponse<IReadOnlyList<Zone>>> GetZonesAsync(
             CancellationToken cancellationToken,
             PagedZoneParameters parameters = null,
             CloudFlareAuth auth = null)

--- a/src/CloudFlare.NET/CloudFlareResponseBase.cs
+++ b/src/CloudFlare.NET/CloudFlareResponseBase.cs
@@ -13,13 +13,12 @@
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class CloudFlareResponseBase
     {
-        private static readonly IReadOnlyList<CloudFlareError> EmptyErrors =
-            Enumerable.Empty<CloudFlareError>().ToList();
+        private static readonly IReadOnlyList<CloudFlareError> EmptyErrors = new CloudFlareError[0];
 
         private static readonly CloudFlareResultInfo DefaultResultInfo =
             new CloudFlareResultInfo(-1, -1, -1, -1);
 
-        private static readonly IReadOnlyList<string> EmptyMessages = Enumerable.Empty<string>().ToList();
+        private static readonly IReadOnlyList<string> EmptyMessages = new string[0];
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CloudFlareResponseBase"/> class.

--- a/src/CloudFlare.NET/CloudFlareResponseBase.cs
+++ b/src/CloudFlare.NET/CloudFlareResponseBase.cs
@@ -16,7 +16,7 @@
         private static readonly IReadOnlyList<CloudFlareError> EmptyErrors = new CloudFlareError[0];
 
         private static readonly CloudFlareResultInfo DefaultResultInfo =
-            new CloudFlareResultInfo(-1, -1, -1, -1);
+            new CloudFlareResultInfo(-1, -1, -1, -1, -1);
 
         private static readonly IReadOnlyList<string> EmptyMessages = new string[0];
 

--- a/src/CloudFlare.NET/CloudFlareResultInfo.cs
+++ b/src/CloudFlare.NET/CloudFlareResultInfo.cs
@@ -14,34 +14,41 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="CloudFlareResultInfo"/> class.
         /// </summary>
-        public CloudFlareResultInfo(int page, int perPage, int count, int totalCount)
+        public CloudFlareResultInfo(int page, int totalPages, int perPage, int count, int totalCount)
         {
             Page = page;
+            TotalPages = totalPages;
             PerPage = perPage;
             Count = count;
             TotalCount = totalCount;
         }
 
         /// <summary>
-        /// Gets the TBD.
+        /// Gets the page number of the current <see cref="CloudFlareResponse{T}"/>.
         /// </summary>
         [JsonProperty("page")]
         public int Page { get; }
 
         /// <summary>
-        /// Gets the TBD.
+        /// Gets the total number of pages.
+        /// </summary>
+        [JsonProperty("total_pages")]
+        public int TotalPages { get; }
+
+        /// <summary>
+        /// Gets the number of results per page.
         /// </summary>
         [JsonProperty("per_page")]
         public int PerPage { get; }
 
         /// <summary>
-        /// Gets the TBD.
+        /// Gets the number of results of the current <see cref="CloudFlareResponse{T}"/>.
         /// </summary>
         [JsonProperty("count")]
         public int Count { get; }
 
         /// <summary>
-        /// Gets the TBD.
+        /// Gets the total number of results.
         /// </summary>
         [JsonProperty("total_count")]
         public int TotalCount { get; }

--- a/src/CloudFlare.NET/DnsRecordClientExtensions.cs
+++ b/src/CloudFlare.NET/DnsRecordClientExtensions.cs
@@ -47,5 +47,42 @@
 
             return client.GetDnsRecordsAsync(zoneId, CancellationToken.None, parameters, auth);
         }
+
+        /// <summary>
+        /// Gets the zones for the subscription.
+        /// </summary>
+        /// <seealso href="https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records"/>
+        public static Task<IEnumerable<DnsRecord>> GetAllDnsRecordsAsync(
+            this IDnsRecordClient client,
+            IdentifierTag zoneId,
+            PagedDnsRecordParameters parameters = null)
+        {
+            if (client == null)
+                throw new ArgumentNullException(nameof(client));
+            if (zoneId == null)
+                throw new ArgumentNullException(nameof(zoneId));
+
+            return client.GetAllDnsRecordsAsync(zoneId, CancellationToken.None, parameters);
+        }
+
+        /// <summary>
+        /// Gets the zones for the subscription.
+        /// </summary>
+        /// <seealso href="https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records"/>
+        public static Task<IEnumerable<DnsRecord>> GetAllDnsRecordsAsync(
+            this IDnsRecordClient client,
+            IdentifierTag zoneId,
+            CloudFlareAuth auth,
+            PagedDnsRecordParameters parameters = null)
+        {
+            if (client == null)
+                throw new ArgumentNullException(nameof(client));
+            if (zoneId == null)
+                throw new ArgumentNullException(nameof(zoneId));
+            if (auth == null)
+                throw new ArgumentNullException(nameof(auth));
+
+            return client.GetAllDnsRecordsAsync(zoneId, CancellationToken.None, parameters, auth);
+        }
     }
 }

--- a/src/CloudFlare.NET/DnsRecordClientExtensions.cs
+++ b/src/CloudFlare.NET/DnsRecordClientExtensions.cs
@@ -18,14 +18,34 @@
         public static Task<IReadOnlyList<DnsRecord>> GetDnsRecordsAsync(
             this IDnsRecordClient client,
             IdentifierTag zoneId,
-            CloudFlareAuth auth = null)
+            PagedDnsRecordParameters parameters = null)
         {
             if (client == null)
                 throw new ArgumentNullException(nameof(client));
             if (zoneId == null)
                 throw new ArgumentNullException(nameof(zoneId));
 
-            return client.GetDnsRecordsAsync(zoneId, CancellationToken.None, auth);
+            return client.GetDnsRecordsAsync(zoneId, CancellationToken.None, parameters);
+        }
+
+        /// <summary>
+        /// Gets the zones for the subscription.
+        /// </summary>
+        /// <seealso href="https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records"/>
+        public static Task<IReadOnlyList<DnsRecord>> GetDnsRecordsAsync(
+            this IDnsRecordClient client,
+            IdentifierTag zoneId,
+            CloudFlareAuth auth,
+            PagedDnsRecordParameters parameters = null)
+        {
+            if (client == null)
+                throw new ArgumentNullException(nameof(client));
+            if (zoneId == null)
+                throw new ArgumentNullException(nameof(zoneId));
+            if (auth == null)
+                throw new ArgumentNullException(nameof(auth));
+
+            return client.GetDnsRecordsAsync(zoneId, CancellationToken.None, parameters, auth);
         }
     }
 }

--- a/src/CloudFlare.NET/DnsRecordClientExtensions.cs
+++ b/src/CloudFlare.NET/DnsRecordClientExtensions.cs
@@ -15,7 +15,7 @@
         /// Gets the zones for the subscription.
         /// </summary>
         /// <seealso href="https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records"/>
-        public static Task<IReadOnlyList<DnsRecord>> GetDnsRecordsAsync(
+        public static Task<CloudFlareResponse<IReadOnlyList<DnsRecord>>> GetDnsRecordsAsync(
             this IDnsRecordClient client,
             IdentifierTag zoneId,
             PagedDnsRecordParameters parameters = null)
@@ -32,7 +32,7 @@
         /// Gets the zones for the subscription.
         /// </summary>
         /// <seealso href="https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records"/>
-        public static Task<IReadOnlyList<DnsRecord>> GetDnsRecordsAsync(
+        public static Task<CloudFlareResponse<IReadOnlyList<DnsRecord>>> GetDnsRecordsAsync(
             this IDnsRecordClient client,
             IdentifierTag zoneId,
             CloudFlareAuth auth,

--- a/src/CloudFlare.NET/HttpClientDnsRecordExtensions.cs
+++ b/src/CloudFlare.NET/HttpClientDnsRecordExtensions.cs
@@ -17,7 +17,7 @@
         /// Gets the zones for the account specified by the <paramref name="auth"/> details.
         /// </summary>
         /// <seealso href="https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records"/>
-        public static Task<IReadOnlyList<DnsRecord>> GetDnsRecordsAsync(
+        public static Task<CloudFlareResponse<IReadOnlyList<DnsRecord>>> GetDnsRecordsAsync(
             this HttpClient client,
             IdentifierTag zoneId,
             CancellationToken cancellationToken,
@@ -33,7 +33,7 @@
                 uri = new UriBuilder(uri) { Query = parameters.ToQuery() }.Uri;
             }
 
-            return client.GetCloudFlareResultAsync<IReadOnlyList<DnsRecord>>(uri, auth, cancellationToken);
+            return client.GetCloudFlareResponseAsync<IReadOnlyList<DnsRecord>>(uri, auth, cancellationToken);
         }
     }
 }

--- a/src/CloudFlare.NET/HttpClientDnsRecordExtensions.cs
+++ b/src/CloudFlare.NET/HttpClientDnsRecordExtensions.cs
@@ -27,7 +27,7 @@
                 throw new ArgumentNullException(nameof(zoneId));
 
             Uri uri = new Uri(CloudFlareConstants.BaseUri, $"zones/{zoneId}/dns_records");
-            return client.GetAsync<IReadOnlyList<DnsRecord>>(uri, auth, cancellationToken);
+            return client.GetCloudFlareResultAsync<IReadOnlyList<DnsRecord>>(uri, auth, cancellationToken);
         }
     }
 }

--- a/src/CloudFlare.NET/HttpClientDnsRecordExtensions.cs
+++ b/src/CloudFlare.NET/HttpClientDnsRecordExtensions.cs
@@ -21,12 +21,18 @@
             this HttpClient client,
             IdentifierTag zoneId,
             CancellationToken cancellationToken,
-            CloudFlareAuth auth)
+            CloudFlareAuth auth,
+            PagedDnsRecordParameters parameters = null)
         {
             if (zoneId == null)
                 throw new ArgumentNullException(nameof(zoneId));
 
             Uri uri = new Uri(CloudFlareConstants.BaseUri, $"zones/{zoneId}/dns_records");
+            if (parameters != null)
+            {
+                uri = new UriBuilder(uri) { Query = parameters.ToQuery() }.Uri;
+            }
+
             return client.GetCloudFlareResultAsync<IReadOnlyList<DnsRecord>>(uri, auth, cancellationToken);
         }
     }

--- a/src/CloudFlare.NET/HttpClientExtensions.cs
+++ b/src/CloudFlare.NET/HttpClientExtensions.cs
@@ -17,7 +17,7 @@
         /// Gets the <see cref="CloudFlareResponse{T}"/> of a CloudFlare API <paramref name="response"/>.
         /// </summary>
         /// <typeparam name="T">The type of the <see cref="CloudFlareResponse{T}.Result"/>.</typeparam>
-        public static async Task<CloudFlareResponse<T>> GetResultAsync<T>(
+        public static async Task<CloudFlareResponse<T>> ReadCloudFlareResponseAsync<T>(
             this HttpResponseMessage response,
             CancellationToken cancellationToken)
             where T : class
@@ -57,10 +57,10 @@
         }
 
         /// <summary>
-        /// Executes a <see cref="HttpMethod.Get"/> request returning the type specified by <typeparamref name="T"/>.
+        /// Executes a <see cref="HttpMethod.Get"/> request returning the <see cref="CloudFlareResponse{T}"/>.
         /// </summary>
         /// <typeparam name="T">The type of the <see cref="CloudFlareResponse{T}.Result"/>.</typeparam>
-        public static async Task<T> GetAsync<T>(
+        public static async Task<CloudFlareResponse<T>> GetCloudFlareResponseAsync<T>(
             this HttpClient client,
             Uri uri,
             CloudFlareAuth auth,
@@ -84,10 +84,27 @@
                 using (response)
                 {
                     CloudFlareResponse<T> cloudFlareResponse =
-                        await response.GetResultAsync<T>(cancellationToken).ConfigureAwait(false);
-                    return cloudFlareResponse.Result;
+                        await response.ReadCloudFlareResponseAsync<T>(cancellationToken).ConfigureAwait(false);
+                    return cloudFlareResponse;
                 }
             }
+        }
+
+        /// <summary>
+        /// Executes a <see cref="HttpMethod.Get"/> request returning the type specified by <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the <see cref="CloudFlareResponse{T}.Result"/>.</typeparam>
+        public static async Task<T> GetCloudFlareResultAsync<T>(
+            this HttpClient client,
+            Uri uri,
+            CloudFlareAuth auth,
+            CancellationToken cancellationToken)
+            where T : class
+        {
+            CloudFlareResponse<T> cloudFlareResponse =
+                await client.GetCloudFlareResponseAsync<T>(uri, auth, cancellationToken);
+
+            return cloudFlareResponse.Result;
         }
     }
 }

--- a/src/CloudFlare.NET/HttpClientZoneExtensions.cs
+++ b/src/CloudFlare.NET/HttpClientZoneExtensions.cs
@@ -17,7 +17,7 @@
         /// Gets the zones for the account specified by the <paramref name="auth"/> details.
         /// </summary>
         /// <seealso href="https://api.cloudflare.com/#zone-list-zones"/>
-        public static Task<IReadOnlyList<Zone>> GetZonesAsync(
+        public static Task<CloudFlareResponse<IReadOnlyList<Zone>>> GetZonesAsync(
             this HttpClient client,
             CancellationToken cancellationToken,
             CloudFlareAuth auth,
@@ -29,7 +29,7 @@
                 uri = new UriBuilder(uri) { Query = parameters.ToQuery() }.Uri;
             }
 
-            return client.GetCloudFlareResultAsync<IReadOnlyList<Zone>>(uri, auth, cancellationToken);
+            return client.GetCloudFlareResponseAsync<IReadOnlyList<Zone>>(uri, auth, cancellationToken);
         }
 
         /// <summary>

--- a/src/CloudFlare.NET/HttpClientZoneExtensions.cs
+++ b/src/CloudFlare.NET/HttpClientZoneExtensions.cs
@@ -29,7 +29,7 @@
                 uri = new UriBuilder(uri) { Query = parameters.ToQuery() }.Uri;
             }
 
-            return client.GetAsync<IReadOnlyList<Zone>>(uri, auth, cancellationToken);
+            return client.GetCloudFlareResultAsync<IReadOnlyList<Zone>>(uri, auth, cancellationToken);
         }
 
         /// <summary>
@@ -46,7 +46,7 @@
                 throw new ArgumentNullException(nameof(zoneId));
 
             Uri uri = new Uri(CloudFlareConstants.BaseUri, $"zones/{zoneId}");
-            return client.GetAsync<Zone>(uri, auth, cancellationToken);
+            return client.GetCloudFlareResultAsync<Zone>(uri, auth, cancellationToken);
         }
     }
 }

--- a/src/CloudFlare.NET/IDnsRecordClient.cs
+++ b/src/CloudFlare.NET/IDnsRecordClient.cs
@@ -21,5 +21,16 @@
             CancellationToken cancellationToken,
             PagedDnsRecordParameters parameters = null,
             CloudFlareAuth auth = null);
+
+        /// <summary>
+        /// Gets all the DNS records for the zone with the specified <paramref name="zoneId"/>. Making multiple paged
+        /// requests if necessary.
+        /// </summary>
+        /// <seealso href="https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records"/>
+        Task<IEnumerable<DnsRecord>> GetAllDnsRecordsAsync(
+            IdentifierTag zoneId,
+            CancellationToken cancellationToken,
+            PagedDnsRecordParameters parameters = null,
+            CloudFlareAuth auth = null);
     }
 }

--- a/src/CloudFlare.NET/IDnsRecordClient.cs
+++ b/src/CloudFlare.NET/IDnsRecordClient.cs
@@ -16,7 +16,7 @@
         /// Gets the DNS records for the zone with the specified <paramref name="zoneId"/>.
         /// </summary>
         /// <seealso href="https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records"/>
-        Task<IReadOnlyList<DnsRecord>> GetDnsRecordsAsync(
+        Task<CloudFlareResponse<IReadOnlyList<DnsRecord>>> GetDnsRecordsAsync(
             IdentifierTag zoneId,
             CancellationToken cancellationToken,
             PagedDnsRecordParameters parameters = null,

--- a/src/CloudFlare.NET/IDnsRecordClient.cs
+++ b/src/CloudFlare.NET/IDnsRecordClient.cs
@@ -19,6 +19,7 @@
         Task<IReadOnlyList<DnsRecord>> GetDnsRecordsAsync(
             IdentifierTag zoneId,
             CancellationToken cancellationToken,
+            PagedDnsRecordParameters parameters = null,
             CloudFlareAuth auth = null);
     }
 }

--- a/src/CloudFlare.NET/IZoneClient.cs
+++ b/src/CloudFlare.NET/IZoneClient.cs
@@ -16,7 +16,7 @@
         /// Gets the zones for the subscription.
         /// </summary>
         /// <seealso href="https://api.cloudflare.com/#zone-list-zones"/>
-        Task<IReadOnlyList<Zone>> GetZonesAsync(
+        Task<CloudFlareResponse<IReadOnlyList<Zone>>> GetZonesAsync(
             CancellationToken cancellationToken,
             PagedZoneParameters parameters = null,
             CloudFlareAuth auth = null);

--- a/src/CloudFlare.NET/IZoneClient.cs
+++ b/src/CloudFlare.NET/IZoneClient.cs
@@ -22,6 +22,15 @@
             CloudFlareAuth auth = null);
 
         /// <summary>
+        /// Gets all the zones for the subscription. Making multiple paged requests if necessary.
+        /// </summary>
+        /// <seealso href="https://api.cloudflare.com/#zone-list-zones"/>
+        Task<IEnumerable<Zone>> GetAllZonesAsync(
+            CancellationToken cancellationToken,
+            PagedZoneParameters parameters = null,
+            CloudFlareAuth auth = null);
+
+        /// <summary>
         /// Gets the zone with the specified <paramref name="zoneId"/>.
         /// </summary>
         /// <seealso href="https://api.cloudflare.com/#zone-zone-details"/>

--- a/src/CloudFlare.NET/PagedDnsRecordOrderFieldTypes.cs
+++ b/src/CloudFlare.NET/PagedDnsRecordOrderFieldTypes.cs
@@ -1,0 +1,27 @@
+﻿namespace CloudFlare.NET
+{
+    using System.Diagnostics.CodeAnalysis;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    // ReSharper disable InconsistentNaming
+#pragma warning disable 1591
+
+    /// <summary>
+    /// The fields by which DNS records can be ordered.
+    /// </summary>
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1602:EnumerationItemsMustBeDocumented",
+        Justification = "Names are self-explanatory.")]
+    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1303:ConstFieldNamesMustBeginWithUpperCaseLetter",
+        Justification = "Named to match serialized values.")]
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum PagedDnsRecordOrderFieldTypes
+    {
+        none,
+        type,
+        name,
+        content,
+        ttl,
+        proxied,
+    }
+}

--- a/src/CloudFlare.NET/PagedDnsRecordParameters.cs
+++ b/src/CloudFlare.NET/PagedDnsRecordParameters.cs
@@ -7,50 +7,58 @@
     using Newtonsoft.Json.Linq;
 
     /// <summary>
-    /// Specifies the parameters of the <see cref="IZoneClient.GetZonesAsync"/> request.
+    /// Specifies the parameters of the <see cref="IDnsRecordClient.GetDnsRecordsAsync"/> request.
     /// </summary>
-    /// <seealso href="https://api.cloudflare.com/#zone-list-zones"/>
-    public class PagedZoneParameters : PagedParameters<PagedZoneOrderFieldTypes>
+    /// <seealso href="https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records"/>
+    public class PagedDnsRecordParameters : PagedParameters<PagedDnsRecordOrderFieldTypes>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PagedZoneParameters"/> class.
+        /// Initializes a new instance of the <see cref="PagedDnsRecordParameters"/> class.
         /// </summary>
-        public PagedZoneParameters(
+        public PagedDnsRecordParameters(
+            DnsRecordType? type = null,
             string name = null,
-            ZoneStatusType? status = null,
+            string content = null,
             int page = 0,
             int perPage = 0,
-            PagedZoneOrderFieldTypes order = default(PagedZoneOrderFieldTypes),
+            PagedDnsRecordOrderFieldTypes order = default(PagedDnsRecordOrderFieldTypes),
             PagedParametersOrderType direction = default(PagedParametersOrderType),
             PagedParametersMatchType match = default(PagedParametersMatchType))
             : base(page, perPage, order, direction, match)
         {
+            Type = type;
             Name = name;
-            Status = status;
+            Content = content;
         }
 
         /// <summary>
-        /// A domain name.
+        /// DNS record type
+        /// </summary>
+        [JsonProperty("type")]
+        public DnsRecordType? Type { get; }
+
+        /// <summary>
+        /// DNS record name.
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; }
 
         /// <summary>
-        /// Status of the zone
+        /// DNS record content.
         /// </summary>
-        [JsonProperty("status")]
-        public ZoneStatusType? Status { get; }
+        [JsonProperty("content")]
+        public string Content { get; }
 
         /// <summary>
         /// Creates a <see cref="PagedZoneParameters"/> from the <paramref name="data"/> copying any matching
         /// properties.
         /// </summary>
-        public static PagedZoneParameters Create(object data)
+        public static PagedDnsRecordParameters Create(object data)
         {
             if (data == null)
                 throw new ArgumentNullException(nameof(data));
 
-            return JObject.FromObject(data).ToObject<PagedZoneParameters>();
+            return JObject.FromObject(data).ToObject<PagedDnsRecordParameters>();
         }
     }
 }

--- a/src/CloudFlare.NET/Properties/AssemblyInfo.cs
+++ b/src/CloudFlare.NET/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.5.0")]
-[assembly: AssemblyFileVersion("0.0.5.0")]
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]

--- a/src/CloudFlare.NET/Zone.cs
+++ b/src/CloudFlare.NET/Zone.cs
@@ -13,7 +13,7 @@
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Zone : IIdentifier, IModified
     {
-        private static readonly IReadOnlyList<string> EmptyStrings = Enumerable.Empty<string>().ToArray();
+        private static readonly IReadOnlyList<string> EmptyStrings = new string[0];
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Zone"/> class.

--- a/src/CloudFlare.NET/ZoneClientExtensions.cs
+++ b/src/CloudFlare.NET/ZoneClientExtensions.cs
@@ -45,6 +45,37 @@
         /// <summary>
         /// Gets the zones for the subscription.
         /// </summary>
+        /// <seealso href="https://api.cloudflare.com/#zone-list-zones"/>
+        public static Task<IEnumerable<Zone>> GetAllZonesAsync(
+            this IZoneClient client,
+            PagedZoneParameters parameters = null)
+        {
+            if (client == null)
+                throw new ArgumentNullException(nameof(client));
+
+            return client.GetAllZonesAsync(CancellationToken.None, parameters);
+        }
+
+        /// <summary>
+        /// Gets the zones for the subscription.
+        /// </summary>
+        /// <seealso href="https://api.cloudflare.com/#zone-list-zones"/>
+        public static Task<IEnumerable<Zone>> GetAllZonesAsync(
+            this IZoneClient client,
+            CloudFlareAuth auth,
+            PagedZoneParameters parameters = null)
+        {
+            if (client == null)
+                throw new ArgumentNullException(nameof(client));
+            if (auth == null)
+                throw new ArgumentNullException(nameof(auth));
+
+            return client.GetAllZonesAsync(CancellationToken.None, parameters, auth);
+        }
+
+        /// <summary>
+        /// Gets the zones for the subscription.
+        /// </summary>
         /// <seealso href="https://api.cloudflare.com/#zone-zone-details"/>
         public static Task<Zone> GetZoneAsync(
             this IZoneClient client,

--- a/src/CloudFlare.NET/ZoneClientExtensions.cs
+++ b/src/CloudFlare.NET/ZoneClientExtensions.cs
@@ -15,7 +15,7 @@
         /// Gets the zones for the subscription.
         /// </summary>
         /// <seealso href="https://api.cloudflare.com/#zone-list-zones"/>
-        public static Task<IReadOnlyList<Zone>> GetZonesAsync(
+        public static Task<CloudFlareResponse<IReadOnlyList<Zone>>> GetZonesAsync(
             this IZoneClient client,
             PagedZoneParameters parameters = null)
         {
@@ -29,7 +29,7 @@
         /// Gets the zones for the subscription.
         /// </summary>
         /// <seealso href="https://api.cloudflare.com/#zone-list-zones"/>
-        public static Task<IReadOnlyList<Zone>> GetZonesAsync(
+        public static Task<CloudFlareResponse<IReadOnlyList<Zone>>> GetZonesAsync(
             this IZoneClient client,
             CloudFlareAuth auth,
             PagedZoneParameters parameters = null)

--- a/src/CloudFlare.NET/packages.config
+++ b/src/CloudFlare.NET/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.Bcl" version="1.1.9" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable45-net45+win8+wp8+wpa81" />
-  <package id="Newtonsoft.Json" version="6.0.2" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="StyleCop.Analyzers" version="1.0.0-beta008" targetFramework="portable45-net45+win8+wp8+wpa81" developmentDependency="true" />
 </packages>

--- a/src/CloudFlare.NET/packages.config
+++ b/src/CloudFlare.NET/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AsyncFixer" version="1.0.0.0" targetFramework="portable45-net45+win8+wp8+wpa81" developmentDependency="true" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.0" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="Microsoft.Bcl" version="1.1.9" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable45-net45+win8+wp8+wpa81" />
-  <package id="StyleCop.Analyzers" version="1.0.0-beta008" targetFramework="portable45-net45+win8+wp8+wpa81" developmentDependency="true" />
+  <package id="StyleCop.Analyzers" version="1.0.0-beta009" targetFramework="portable45-net45+win8+wp8+wpa81" developmentDependency="true" />
 </packages>

--- a/src/Tests/CloudFlare.NET.IntegrationTests/DnsRecordsSpec.cs
+++ b/src/Tests/CloudFlare.NET.IntegrationTests/DnsRecordsSpec.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading;
     using Machine.Specifications;
 
     [Subject("Zones")]
@@ -18,7 +17,8 @@
         {
             var client = new CloudFlareClient();
             _auth = new CloudFlareAuth(Helper.AuthEmail, Helper.AuthKey);
-            _zone = client.GetZonesAsync(_auth).Await().AsTask.Result.First();
+            CloudFlareResponse<IReadOnlyList<Zone>> response = client.GetZonesAsync(_auth).Await();
+            _zone = response.Result.First();
             _client = client;
         };
 

--- a/src/Tests/CloudFlare.NET.IntegrationTests/DnsRecordsSpec.cs
+++ b/src/Tests/CloudFlare.NET.IntegrationTests/DnsRecordsSpec.cs
@@ -11,7 +11,7 @@
         static IDnsRecordClient _client;
         static CloudFlareAuth _auth;
         static Zone _zone;
-        static IReadOnlyList<DnsRecord> _dnsRecords;
+        static CloudFlareResponse<IReadOnlyList<DnsRecord>> _response;
 
         Establish context = () =>
         {
@@ -22,8 +22,8 @@
             _client = client;
         };
 
-        Because of = () => _dnsRecords = _client.GetDnsRecordsAsync(_zone.Id, _auth).Await().AsTask.Result;
+        Because of = () => _response = _client.GetDnsRecordsAsync(_zone.Id, _auth).Await();
 
-        It should_return_the_zones = () => _dnsRecords.ShouldNotBeEmpty();
+        It should_return_the_zones = () => _response.Result.ShouldNotBeEmpty();
     }
 }

--- a/src/Tests/CloudFlare.NET.IntegrationTests/ZonesSpec.cs
+++ b/src/Tests/CloudFlare.NET.IntegrationTests/ZonesSpec.cs
@@ -10,7 +10,7 @@
     {
         static IZoneClient _client;
         static CloudFlareAuth _auth;
-        static IReadOnlyList<Zone> _zones;
+        static CloudFlareResponse<IReadOnlyList<Zone>> _response;
 
         Establish context = () =>
         {
@@ -18,8 +18,8 @@
             _auth = new CloudFlareAuth(Helper.AuthEmail, Helper.AuthKey);
         };
 
-        Because of = () => _zones = _client.GetZonesAsync(_auth).Await().AsTask.Result;
+        Because of = () => _response = _client.GetZonesAsync(_auth).Await();
 
-        It should_return_the_zones = () => _zones.ShouldNotBeEmpty();
+        It should_return_the_zones = () => _response.Result.ShouldNotBeEmpty();
     }
 }

--- a/src/Tests/CloudFlare.NET.Tests/CloudFlare.NET.Tests.csproj
+++ b/src/Tests/CloudFlare.NET.Tests/CloudFlare.NET.Tests.csproj
@@ -120,6 +120,7 @@
     <Compile Include="RequiresArgNullEx.cs" />
     <Compile Include="RequiresArgNullExAutoMoqAttribute.cs" />
     <Compile Include="Serialization\BehaviorTemplates.cs" />
+    <Compile Include="Serialization\PagedDnsRecordParametersSerializationSpec.cs" />
     <Compile Include="Serialization\PagedZoneParametersSerializationSpec.cs" />
     <Compile Include="ZoneClientExtensionsSpec.cs" />
     <Compile Include="Serialization\DnsRecordSerializationSpec.cs" />

--- a/src/Tests/CloudFlare.NET.Tests/CloudFlareCustomization.cs
+++ b/src/Tests/CloudFlare.NET.Tests/CloudFlareCustomization.cs
@@ -23,6 +23,7 @@
             fixture.Register<IReadOnlyList<string>>(fixture.Create<string[]>);
             fixture.Register<IReadOnlyList<CloudFlareError>>(fixture.Create<CloudFlareError[]>);
             fixture.Register<IReadOnlyList<Zone>>(fixture.Create<Zone[]>);
+            fixture.Register<IReadOnlyList<DnsRecord>>(fixture.Create<DnsRecord[]>);
             fixture.Register(() => JObject.FromObject(fixture.Create<CloudFlareResponseBase>()));
         }
     }

--- a/src/Tests/CloudFlare.NET.Tests/DnsRecordClientExtensionsSpec.cs
+++ b/src/Tests/CloudFlare.NET.Tests/DnsRecordClientExtensionsSpec.cs
@@ -15,15 +15,15 @@
         static Mock<IDnsRecordClient> _dnsRecordClientMock;
         static CloudFlareAuth _auth;
         static IdentifierTag _zoneId;
-        static IReadOnlyList<DnsRecord> _expected;
-        static IReadOnlyList<DnsRecord> _actual;
+        static CloudFlareResponse<IReadOnlyList<DnsRecord>> _expected;
+        static CloudFlareResponse<IReadOnlyList<DnsRecord>> _actual;
 
         Establish context = () =>
         {
             _dnsRecordClientMock = _fixture.Create<Mock<IDnsRecordClient>>();
             _auth = _fixture.Create<CloudFlareAuth>();
             _zoneId = _fixture.Create<IdentifierTag>();
-            _expected = _fixture.Create<DnsRecord[]>();
+            _expected = _fixture.Create<CloudFlareResponse<IReadOnlyList<DnsRecord>>>();
             _dnsRecordClientMock
                 .Setup(
                     c => c.GetDnsRecordsAsync(
@@ -35,9 +35,9 @@
         };
 
         Because of =
-            () => _actual = _dnsRecordClientMock.Object.GetDnsRecordsAsync(_zoneId, _auth).Await().AsTask.Result;
+            () => _actual = _dnsRecordClientMock.Object.GetDnsRecordsAsync(_zoneId, _auth).Await();
 
-        It should_return_the_dns_record = () => _actual.ShouldBeTheSameAs(_expected);
+        It should_return_the_dns_records = () => _actual.ShouldBeTheSameAs(_expected);
     }
 
     [Subject(typeof(DnsRecordClientExtensions))]
@@ -46,15 +46,15 @@
         static Mock<IDnsRecordClient> _dnsRecordClientMock;
         static IdentifierTag _zoneId;
         static PagedDnsRecordParameters _parameters;
-        static IReadOnlyList<DnsRecord> _expected;
-        static IReadOnlyList<DnsRecord> _actual;
+        static CloudFlareResponse<IReadOnlyList<DnsRecord>> _expected;
+        static CloudFlareResponse<IReadOnlyList<DnsRecord>> _actual;
 
         Establish context = () =>
         {
             _dnsRecordClientMock = _fixture.Create<Mock<IDnsRecordClient>>();
             _zoneId = _fixture.Create<IdentifierTag>();
             _parameters = _fixture.Create<PagedDnsRecordParameters>();
-            _expected = _fixture.Create<DnsRecord[]>();
+            _expected = _fixture.Create<CloudFlareResponse<IReadOnlyList<DnsRecord>>>();
             _dnsRecordClientMock
                 .Setup(
                     c => c.GetDnsRecordsAsync(_zoneId, CancellationToken.None, _parameters, default(CloudFlareAuth)))
@@ -62,8 +62,8 @@
         };
 
         Because of =
-            () => _actual = _dnsRecordClientMock.Object.GetDnsRecordsAsync(_zoneId, _parameters).Await().AsTask.Result;
+            () => _actual = _dnsRecordClientMock.Object.GetDnsRecordsAsync(_zoneId, _parameters).Await();
 
-        It should_return_the_dns_record = () => _actual.ShouldBeTheSameAs(_expected);
+        It should_return_the_dns_records = () => _actual.ShouldBeTheSameAs(_expected);
     }
 }

--- a/src/Tests/CloudFlare.NET.Tests/DnsRecordClientExtensionsSpec.cs
+++ b/src/Tests/CloudFlare.NET.Tests/DnsRecordClientExtensionsSpec.cs
@@ -10,7 +10,7 @@
     using It = Machine.Specifications.It;
 
     [Subject(typeof(DnsRecordClientExtensions))]
-    public class When_getting_all_dns_records : FixtureContext
+    public class When_getting_dns_records : FixtureContext
     {
         static Mock<IDnsRecordClient> _dnsRecordClientMock;
         static CloudFlareAuth _auth;
@@ -41,7 +41,7 @@
     }
 
     [Subject(typeof(DnsRecordClientExtensions))]
-    public class When_getting_all_dns_records_with_parameters : FixtureContext
+    public class When_getting_dns_records_with_parameters : FixtureContext
     {
         static Mock<IDnsRecordClient> _dnsRecordClientMock;
         static IdentifierTag _zoneId;

--- a/src/Tests/CloudFlare.NET.Tests/DnsRecordClientExtensionsSpec.cs
+++ b/src/Tests/CloudFlare.NET.Tests/DnsRecordClientExtensionsSpec.cs
@@ -10,7 +10,7 @@
     using It = Machine.Specifications.It;
 
     [Subject(typeof(DnsRecordClientExtensions))]
-    public class When_getting_dnsRecords : FixtureContext
+    public class When_getting_all_dns_records : FixtureContext
     {
         static Mock<IDnsRecordClient> _dnsRecordClientMock;
         static CloudFlareAuth _auth;
@@ -25,12 +25,45 @@
             _zoneId = _fixture.Create<IdentifierTag>();
             _expected = _fixture.Create<DnsRecord[]>();
             _dnsRecordClientMock
-                .Setup(c => c.GetDnsRecordsAsync(_zoneId, CancellationToken.None, _auth))
+                .Setup(
+                    c => c.GetDnsRecordsAsync(
+                        _zoneId,
+                        CancellationToken.None,
+                        default(PagedDnsRecordParameters),
+                        _auth))
                 .ReturnsAsync(_expected);
         };
 
-        Because of = () => _actual = _dnsRecordClientMock.Object.GetDnsRecordsAsync(_zoneId, _auth).Await().AsTask.Result;
+        Because of =
+            () => _actual = _dnsRecordClientMock.Object.GetDnsRecordsAsync(_zoneId, _auth).Await().AsTask.Result;
 
-        It should_return_the_zones = () => _actual.ShouldBeTheSameAs(_expected);
+        It should_return_the_dns_record = () => _actual.ShouldBeTheSameAs(_expected);
+    }
+
+    [Subject(typeof(DnsRecordClientExtensions))]
+    public class When_getting_all_dns_records_with_parameters : FixtureContext
+    {
+        static Mock<IDnsRecordClient> _dnsRecordClientMock;
+        static IdentifierTag _zoneId;
+        static PagedDnsRecordParameters _parameters;
+        static IReadOnlyList<DnsRecord> _expected;
+        static IReadOnlyList<DnsRecord> _actual;
+
+        Establish context = () =>
+        {
+            _dnsRecordClientMock = _fixture.Create<Mock<IDnsRecordClient>>();
+            _zoneId = _fixture.Create<IdentifierTag>();
+            _parameters = _fixture.Create<PagedDnsRecordParameters>();
+            _expected = _fixture.Create<DnsRecord[]>();
+            _dnsRecordClientMock
+                .Setup(
+                    c => c.GetDnsRecordsAsync(_zoneId, CancellationToken.None, _parameters, default(CloudFlareAuth)))
+                .ReturnsAsync(_expected);
+        };
+
+        Because of =
+            () => _actual = _dnsRecordClientMock.Object.GetDnsRecordsAsync(_zoneId, _parameters).Await().AsTask.Result;
+
+        It should_return_the_dns_record = () => _actual.ShouldBeTheSameAs(_expected);
     }
 }

--- a/src/Tests/CloudFlare.NET.Tests/DnsRecordClientExtensionsSpec.cs
+++ b/src/Tests/CloudFlare.NET.Tests/DnsRecordClientExtensionsSpec.cs
@@ -34,8 +34,7 @@
                 .ReturnsAsync(_expected);
         };
 
-        Because of =
-            () => _actual = _dnsRecordClientMock.Object.GetDnsRecordsAsync(_zoneId, _auth).Await();
+        Because of = () => _actual = _dnsRecordClientMock.Object.GetDnsRecordsAsync(_zoneId, _auth).Await();
 
         It should_return_the_dns_records = () => _actual.ShouldBeTheSameAs(_expected);
     }
@@ -61,9 +60,71 @@
                 .ReturnsAsync(_expected);
         };
 
-        Because of =
-            () => _actual = _dnsRecordClientMock.Object.GetDnsRecordsAsync(_zoneId, _parameters).Await();
+        Because of = () => _actual = _dnsRecordClientMock.Object.GetDnsRecordsAsync(_zoneId, _parameters).Await();
 
         It should_return_the_dns_records = () => _actual.ShouldBeTheSameAs(_expected);
+    }
+
+    [Subject(typeof(DnsRecordClientExtensions))]
+    public class When_getting_all_dns_records : FixtureContext
+    {
+        static Mock<IDnsRecordClient> _dnsRecordClientMock;
+        static CloudFlareAuth _auth;
+        static IdentifierTag _zoneId;
+        static IEnumerable<DnsRecord> _expected;
+        static IEnumerable<DnsRecord> _actual;
+
+        Establish context = () =>
+        {
+            _dnsRecordClientMock = _fixture.Create<Mock<IDnsRecordClient>>();
+            _auth = _fixture.Create<CloudFlareAuth>();
+            _zoneId = _fixture.Create<IdentifierTag>();
+            _expected = _fixture.CreateMany<DnsRecord>();
+            _dnsRecordClientMock
+                .Setup(
+                    c => c.GetAllDnsRecordsAsync(
+                        _zoneId,
+                        CancellationToken.None,
+                        default(PagedDnsRecordParameters),
+                        _auth))
+                .ReturnsAsync(_expected);
+        };
+
+        Because of =
+            () => _actual = _dnsRecordClientMock.Object.GetAllDnsRecordsAsync(_zoneId, _auth).Await().AsTask.Result;
+
+        It should_return_all_the_dns_records = () => _actual.ShouldBeTheSameAs(_expected);
+    }
+
+    [Subject(typeof(DnsRecordClientExtensions))]
+    public class When_getting_all_dns_records_with_parameters : FixtureContext
+    {
+        static Mock<IDnsRecordClient> _dnsRecordClientMock;
+        static IdentifierTag _zoneId;
+        static PagedDnsRecordParameters _parameters;
+        static IEnumerable<DnsRecord> _expected;
+        static IEnumerable<DnsRecord> _actual;
+
+        Establish context = () =>
+        {
+            _dnsRecordClientMock = _fixture.Create<Mock<IDnsRecordClient>>();
+            _zoneId = _fixture.Create<IdentifierTag>();
+            _parameters = _fixture.Create<PagedDnsRecordParameters>();
+            _expected = _fixture.CreateMany<DnsRecord>();
+            _dnsRecordClientMock
+                .Setup(
+                    c => c.GetAllDnsRecordsAsync(
+                        _zoneId,
+                        CancellationToken.None,
+                        _parameters,
+                        default(CloudFlareAuth)))
+                .ReturnsAsync(_expected);
+        };
+
+        Because of =
+            () => _actual = _dnsRecordClientMock.Object.GetAllDnsRecordsAsync(_zoneId, _parameters).Await()
+                .AsTask.Result;
+
+        It should_return_all_the_dns_records = () => _actual.ShouldBeTheSameAs(_expected);
     }
 }

--- a/src/Tests/CloudFlare.NET.Tests/DnsRecordClientSpec.cs
+++ b/src/Tests/CloudFlare.NET.Tests/DnsRecordClientSpec.cs
@@ -8,7 +8,7 @@
     using Ploeh.AutoFixture;
 
     [Subject(typeof(CloudFlareClient))]
-    public class When_getting_all_dns_records : RequestContext
+    public class When_getting_dns_records : RequestContext
     {
         static IdentifierTag _zoneId;
         static CloudFlareResponse<IReadOnlyList<DnsRecord>> _expected;
@@ -37,7 +37,7 @@
     }
 
     [Subject(typeof(CloudFlareClient))]
-    public class When_getting_all_dns_records_with_parameters : RequestContext
+    public class When_getting_dns_records_with_parameters : RequestContext
     {
         static IdentifierTag _zoneId;
         static CloudFlareResponse<IReadOnlyList<DnsRecord>> _expected;

--- a/src/Tests/CloudFlare.NET.Tests/DnsRecordClientSpec.cs
+++ b/src/Tests/CloudFlare.NET.Tests/DnsRecordClientSpec.cs
@@ -11,20 +11,19 @@
     public class When_getting_all_dns_records : RequestContext
     {
         static IdentifierTag _zoneId;
-        static IReadOnlyList<DnsRecord> _expected;
-        static IReadOnlyList<DnsRecord> _actual;
+        static CloudFlareResponse<IReadOnlyList<DnsRecord>> _expected;
+        static CloudFlareResponse<IReadOnlyList<DnsRecord>> _actual;
         static Uri _expectedRequestUri;
 
         Establish context = () =>
         {
             _zoneId = _fixture.Create<IdentifierTag>();
-            var response = _fixture.Create<CloudFlareResponse<IReadOnlyList<DnsRecord>>>();
-            _expected = response.Result;
-            _handler.SetResponseContent(response);
+            _expected = _fixture.Create<CloudFlareResponse<IReadOnlyList<DnsRecord>>>();
+            _handler.SetResponseContent(_expected);
             _expectedRequestUri = new Uri(CloudFlareConstants.BaseUri, $"zones/{_zoneId}/dns_records");
         };
 
-        Because of = () => _actual = _sut.GetDnsRecordsAsync(_zoneId, _auth).Await().AsTask.Result;
+        Because of = () => _actual = _sut.GetDnsRecordsAsync(_zoneId, _auth).Await();
 
         Behaves_like<AuthenticatedRequestBehaviour> authenticated_request_behaviour;
 
@@ -34,24 +33,23 @@
             = () => _handler.Request.RequestUri.ShouldEqual(_expectedRequestUri);
 
         It should_return_the_expected_dns_records = () =>
-            _actual.Select(i => i.AsLikeness().CreateProxy()).SequenceEqual(_expected).ShouldBeTrue();
+            _actual.Result.Select(i => i.AsLikeness().CreateProxy()).SequenceEqual(_expected.Result).ShouldBeTrue();
     }
 
     [Subject(typeof(CloudFlareClient))]
     public class When_getting_all_dns_records_with_parameters : RequestContext
     {
         static IdentifierTag _zoneId;
-        static IReadOnlyList<DnsRecord> _expected;
-        static IReadOnlyList<DnsRecord> _actual;
+        static CloudFlareResponse<IReadOnlyList<DnsRecord>> _expected;
+        static CloudFlareResponse<IReadOnlyList<DnsRecord>> _actual;
         static PagedDnsRecordParameters _parameters;
         static Uri _expectedRequestUri;
 
         Establish context = () =>
         {
             _zoneId = _fixture.Create<IdentifierTag>();
-            var response = _fixture.Create<CloudFlareResponse<IReadOnlyList<DnsRecord>>>();
-            _expected = response.Result;
-            _handler.SetResponseContent(response);
+            _expected = _fixture.Create<CloudFlareResponse<IReadOnlyList<DnsRecord>>>();
+            _handler.SetResponseContent(_expected);
 
             // Auto fixture chooses the default value for enumerations.
             _fixture.Inject(PagedDnsRecordOrderFieldTypes.proxied);
@@ -64,7 +62,7 @@
                 = new Uri(CloudFlareConstants.BaseUri, $"zones/{_zoneId}/dns_records?{_parameters.ToQuery()}");
         };
 
-        Because of = () => _actual = _sut.GetDnsRecordsAsync(_zoneId, _auth, _parameters).Await().AsTask.Result;
+        Because of = () => _actual = _sut.GetDnsRecordsAsync(_zoneId, _auth, _parameters).Await();
 
         Behaves_like<AuthenticatedRequestBehaviour> authenticated_request_behaviour;
 
@@ -74,7 +72,7 @@
             = () => _handler.Request.RequestUri.ShouldEqual(_expectedRequestUri);
 
         It should_return_the_expected_dns_records = () =>
-            _actual.Select(i => i.AsLikeness().CreateProxy()).SequenceEqual(_expected).ShouldBeTrue();
+            _actual.Result.Select(i => i.AsLikeness().CreateProxy()).SequenceEqual(_expected.Result).ShouldBeTrue();
     }
 
     [Subject(typeof(CloudFlareClient))]

--- a/src/Tests/CloudFlare.NET.Tests/DnsRecordClientSpec.cs
+++ b/src/Tests/CloudFlare.NET.Tests/DnsRecordClientSpec.cs
@@ -4,7 +4,9 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
+    using System.Threading;
     using Machine.Specifications;
+    using Newtonsoft.Json.Linq;
     using Ploeh.AutoFixture;
 
     [Subject(typeof(CloudFlareClient))]
@@ -73,6 +75,104 @@
 
         It should_return_the_expected_dns_records = () =>
             _actual.Result.Select(i => i.AsLikeness().CreateProxy()).SequenceEqual(_expected.Result).ShouldBeTrue();
+    }
+
+    [Subject(typeof(CloudFlareClient))]
+    public class When_getting_all_dns_records : GetAllResultsContext<DnsRecord>
+    {
+        static IdentifierTag _zoneId;
+        static Uri _expectedFirstRequestUri;
+        static Uri _expectedSecondRequestUri;
+        static Uri _expectedLastRequestUri;
+
+        Establish context = () =>
+        {
+            _zoneId = _fixture.Create<IdentifierTag>();
+
+            string firstParams = new PagedDnsRecordParameters(page: 1, perPage: 100).ToQuery();
+            string secondParams = new PagedDnsRecordParameters(page: 2, perPage: 100).ToQuery();
+            string lastParams = new PagedDnsRecordParameters(page: 3, perPage: 100).ToQuery();
+
+            _expectedFirstRequestUri
+                = new Uri(CloudFlareConstants.BaseUri, $"zones/{_zoneId}/dns_records?{firstParams}");
+            _expectedSecondRequestUri
+                = new Uri(CloudFlareConstants.BaseUri, $"zones/{_zoneId}/dns_records?{secondParams}");
+            _expectedLastRequestUri
+                = new Uri(CloudFlareConstants.BaseUri, $"zones/{_zoneId}/dns_records?{lastParams}");
+        };
+
+        Because of = () => _actual = _sut.GetAllDnsRecordsAsync(_zoneId, _auth).Await().AsTask.Result;
+
+        Behaves_like<AuthenticatedRequestBehaviour> authenticated_request_behaviour;
+
+        It should_make_a_GET_request = () => _handler.Request.Method.ShouldEqual(HttpMethod.Get);
+
+        It should_request_the_first_page = () => _handler.Requests[0].RequestUri.ShouldEqual(_expectedFirstRequestUri);
+
+        It should_request_the_second_page =
+            () => _handler.Requests[1].RequestUri.ShouldEqual(_expectedSecondRequestUri);
+
+        It should_request_the_last_page = () => _handler.Requests[2].RequestUri.ShouldEqual(_expectedLastRequestUri);
+
+        It should_return_the_expected_dns_records = () =>
+            _actual.Select(z => z.AsLikeness().CreateProxy()).SequenceEqual(_expected).ShouldBeTrue();
+    }
+
+    [Subject(typeof(CloudFlareClient))]
+    public class When_getting_all_dns_records_with_parameters : GetAllResultsContext<DnsRecord>
+    {
+        static IdentifierTag _zoneId;
+        static PagedDnsRecordParameters _parameters;
+        static Uri _expectedFirstRequestUri;
+        static Uri _expectedSecondRequestUri;
+        static Uri _expectedLastRequestUri;
+
+        Establish context = () =>
+        {
+            _zoneId = _fixture.Create<IdentifierTag>();
+
+            // Auto fixture chooses the default value for enumerations.
+            _fixture.Inject(PagedDnsRecordOrderFieldTypes.proxied);
+            _fixture.Inject(PagedParametersOrderType.desc);
+            _fixture.Inject(PagedParametersMatchType.any);
+
+            _parameters = _fixture.Create<PagedDnsRecordParameters>();
+
+            JObject first = JObject.FromObject(_parameters);
+            first.Merge(JObject.FromObject(new { page = 1, per_page = 100 }));
+            string firstParams = first.ToObject<PagedDnsRecordParameters>().ToQuery();
+
+            JObject second = JObject.FromObject(_parameters);
+            second.Merge(JObject.FromObject(new { page = 2, per_page = 100 }));
+            string secondParams = second.ToObject<PagedDnsRecordParameters>().ToQuery();
+
+            JObject last = JObject.FromObject(_parameters);
+            last.Merge(JObject.FromObject(new { page = 3, per_page = 100 }));
+            string lastParams = last.ToObject<PagedDnsRecordParameters>().ToQuery();
+
+            _expectedFirstRequestUri
+                = new Uri(CloudFlareConstants.BaseUri, $"zones/{_zoneId}/dns_records?{firstParams}");
+            _expectedSecondRequestUri
+                = new Uri(CloudFlareConstants.BaseUri, $"zones/{_zoneId}/dns_records?{secondParams}");
+            _expectedLastRequestUri
+                = new Uri(CloudFlareConstants.BaseUri, $"zones/{_zoneId}/dns_records?{lastParams}");
+        };
+
+        Because of = () => _actual = _sut.GetAllDnsRecordsAsync(_zoneId, _auth, _parameters).Await().AsTask.Result;
+
+        Behaves_like<AuthenticatedRequestBehaviour> authenticated_request_behaviour;
+
+        It should_make_a_GET_request = () => _handler.Request.Method.ShouldEqual(HttpMethod.Get);
+
+        It should_request_the_first_page = () => _handler.Requests[0].RequestUri.ShouldEqual(_expectedFirstRequestUri);
+
+        It should_request_the_second_page =
+            () => _handler.Requests[1].RequestUri.ShouldEqual(_expectedSecondRequestUri);
+
+        It should_request_the_last_page = () => _handler.Requests[2].RequestUri.ShouldEqual(_expectedLastRequestUri);
+
+        It should_return_the_expected_dns_records = () =>
+            _actual.Select(z => z.AsLikeness().CreateProxy()).SequenceEqual(_expected).ShouldBeTrue();
     }
 
     [Subject(typeof(CloudFlareClient))]

--- a/src/Tests/CloudFlare.NET.Tests/FixtureContext.cs
+++ b/src/Tests/CloudFlare.NET.Tests/FixtureContext.cs
@@ -33,6 +33,37 @@ namespace CloudFlare.NET
         };
     }
 
+    public abstract class GetAllResultsContext<TResult> : RequestContext
+        where TResult : class
+    {
+        protected static CloudFlareResponse<IReadOnlyList<TResult>> _firstRequest;
+        protected static CloudFlareResponse<IReadOnlyList<TResult>> _secondRequest;
+        protected static CloudFlareResponse<IReadOnlyList<TResult>> _lastRequest;
+        protected static IEnumerable<TResult> _expected;
+        protected static IEnumerable<TResult> _actual;
+
+        Establish context = () =>
+        {
+            _firstRequest = new CloudFlareResponse<IReadOnlyList<TResult>>(
+                true,
+                _fixture.CreateMany<TResult>(100).ToList(),
+                resultInfo: new CloudFlareResultInfo(page: 1, totalPages: 3, perPage: 100, count: 100, totalCount: 250));
+            _secondRequest = new CloudFlareResponse<IReadOnlyList<TResult>>(
+                true,
+                _fixture.CreateMany<TResult>(100).ToList(),
+                resultInfo: new CloudFlareResultInfo(page: 2, totalPages: 3, perPage: 100, count: 100, totalCount: 250));
+            _lastRequest = new CloudFlareResponse<IReadOnlyList<TResult>>(
+                true,
+                _fixture.CreateMany<TResult>(50).ToList(),
+                resultInfo: new CloudFlareResultInfo(page: 3, totalPages: 3, perPage: 100, count: 50, totalCount: 250));
+
+            _handler.AddResponseContent(_firstRequest);
+            _handler.AddResponseContent(_secondRequest);
+            _handler.AddResponseContent(_lastRequest);
+            _expected = _firstRequest.Result.Concat(_secondRequest.Result).Concat(_lastRequest.Result);
+        };
+    }
+
     public abstract class ErredRequestContext : RequestContext
     {
         protected static CloudFlareResponseBase _erredResponse;

--- a/src/Tests/CloudFlare.NET.Tests/HttpHandlers/TestHttpHandler.cs
+++ b/src/Tests/CloudFlare.NET.Tests/HttpHandlers/TestHttpHandler.cs
@@ -66,6 +66,11 @@
             Response = CreateResponse(content, code);
         }
 
+        public void AddResponseContent(object content, HttpStatusCode code = HttpStatusCode.OK)
+        {
+            AddResponseContent(JObject.FromObject(content).ToString(Formatting.None), code);
+        }
+
         public void AddResponseContent(string content, HttpStatusCode code = HttpStatusCode.OK)
         {
             Responses.Add(CreateResponse(content, code));

--- a/src/Tests/CloudFlare.NET.Tests/RequiresArgNullEx.cs
+++ b/src/Tests/CloudFlare.NET.Tests/RequiresArgNullEx.cs
@@ -14,6 +14,7 @@
         [Theory, RequiresArgNullExAutoMoq(typeof(IdentifierTag))]
         [Exclude(Method = "op_Equality")]
         [Exclude(Method = "op_Inequality")]
+        [Exclude(Type = typeof(CloudFlareClient), Method = "GetAllPagedResultsAsync")]
         public Task CloudFlare(MethodData method)
         {
             return method.Execute();

--- a/src/Tests/CloudFlare.NET.Tests/Serialization/BehaviorTemplates.cs
+++ b/src/Tests/CloudFlare.NET.Tests/Serialization/BehaviorTemplates.cs
@@ -80,14 +80,14 @@
         protected static PagedParameters<TOrder> _parameters;
         protected static IReadOnlyDictionary<string, string> _result;
 
-        It should_have_name_page = () => _result["page"].ShouldEqual(_parameters.Page.ToString());
+        It should_have_page_value = () => _result["page"].ShouldEqual(_parameters.Page.ToString());
 
-        It should_have_name_per_page = () => _result["per_page"].ShouldEqual(_parameters.PerPage.ToString());
+        It should_have_per_page_value = () => _result["per_page"].ShouldEqual(_parameters.PerPage.ToString());
 
-        It should_have_name_order = () => _result["order"].ShouldEqual(_parameters.Order.ToString());
+        It should_have_order_value = () => _result["order"].ShouldEqual(_parameters.Order.ToString());
 
-        It should_have_name_direction = () => _result["direction"].ShouldEqual(_parameters.Direction.ToString());
+        It should_have_direction_value = () => _result["direction"].ShouldEqual(_parameters.Direction.ToString());
 
-        It should_have_name_match = () => _result["match"].ShouldEqual(_parameters.Match.ToString());
+        It should_have_match_value = () => _result["match"].ShouldEqual(_parameters.Match.ToString());
     }
 }

--- a/src/Tests/CloudFlare.NET.Tests/Serialization/PagedDnsRecordParametersSerializationSpec.cs
+++ b/src/Tests/CloudFlare.NET.Tests/Serialization/PagedDnsRecordParametersSerializationSpec.cs
@@ -1,4 +1,4 @@
-﻿namespace CloudFlare.NET.Serialization.PagedZoneParametersSpec
+﻿namespace CloudFlare.NET.Serialization.PagedDnsRecordParametersSpec
 {
     using System;
     using System.Collections.Generic;
@@ -10,50 +10,52 @@
     using Newtonsoft.Json.Linq;
     using Ploeh.AutoFixture;
 
-    [Subject(typeof(PagedZoneParameters))]
+    [Subject(typeof(PagedDnsRecordParameters))]
     public class When_serializing : FixtureContext
     {
-        protected static PagedZoneParameters _sut;
+        protected static PagedDnsRecordParameters _sut;
         protected static JObject _json;
 
-        Establish context = () => _sut = _fixture.Create<PagedZoneParameters>();
+        Establish context = () => _sut = _fixture.Create<PagedDnsRecordParameters>();
 
         Because of = () => _json = JObject.FromObject(_sut);
 
-        Behaves_like<PagedParametersSerializeBehavior<PagedZoneOrderFieldTypes>> paged_parameters_serialize_behavior;
+        Behaves_like<PagedParametersSerializeBehavior<PagedDnsRecordOrderFieldTypes>> paged_parameters_serialize_behavior;
+
+        It should_serialize_type = () => _sut.Type.ToString().ShouldEqual(_json["type"].Value<string>());
 
         It should_serialize_name = () => _sut.Name.ShouldEqual(_json["name"].Value<string>());
 
-        It should_serialize_status = () => _sut.Status.ToString().ShouldEqual(_json["status"].Value<string>());
+        It should_serialize_content = () => _sut.Content.ShouldEqual(_json["content"].Value<string>());
     }
 
-    [Subject(typeof(PagedZoneParameters))]
+    [Subject(typeof(PagedDnsRecordParameters))]
     public class When_serializing_and_deserializing : FixtureContext
     {
-        static PagedZoneParameters _expected;
-        static PagedZoneParameters _actual;
+        static PagedDnsRecordParameters _expected;
+        static PagedDnsRecordParameters _actual;
 
-        Establish context = () => _expected = _fixture.Create<PagedZoneParameters>();
+        Establish context = () => _expected = _fixture.Create<PagedDnsRecordParameters>();
 
         Because of = () =>
         {
             var serializeObject = JsonConvert.SerializeObject(_expected);
-            _actual = JObject.FromObject(_expected).ToObject<PagedZoneParameters>();
+            _actual = JObject.FromObject(_expected).ToObject<PagedDnsRecordParameters>();
         };
 
         It should_retain_all_properties = () => _actual.AsLikeness().ShouldEqual(_expected);
     }
 
-    [Subject(typeof(PagedZoneParameters))]
+    [Subject(typeof(PagedDnsRecordParameters))]
     public class When_creating_with_a_subset_of_properties : FixtureContext
     {
-        static PagedZoneParameters _expected;
+        static PagedDnsRecordParameters _expected;
         static object _source;
-        static PagedZoneParameters _actual;
+        static PagedDnsRecordParameters _actual;
 
         Establish context = () =>
         {
-            _expected = _fixture.Create<PagedZoneParameters>();
+            _expected = _fixture.Create<PagedDnsRecordParameters>();
             _source = new
             {
                 _expected.Name,
@@ -62,7 +64,7 @@
             };
         };
 
-        Because of = () => _actual = PagedZoneParameters.Create(_source);
+        Because of = () => _actual = PagedDnsRecordParameters.Create(_source);
 
         It should_retain_all_properties = () =>
             _actual.AsLikeness()
@@ -73,58 +75,60 @@
                 .ShouldEqual(_expected);
     }
 
-    [Subject(typeof (PagedZoneParameters))]
+    [Subject(typeof(PagedDnsRecordParameters))]
     public class When_converting_to_key_value_pair_with_all_default_values
     {
-        static PagedZoneParameters _parameters;
+        static PagedDnsRecordParameters _parameters;
         static IEnumerable<KeyValuePair<string, string>> _result;
 
-        Establish context = () => _parameters = new PagedZoneParameters();
+        Establish context = () => _parameters = new PagedDnsRecordParameters();
 
         Because of = () => _result = _parameters.ToKvp();
 
         It should_have_no_values = () => _result.ShouldBeEmpty();
     }
 
-    [Subject(typeof(PagedZoneParameters))]
+    [Subject(typeof(PagedDnsRecordParameters))]
     public class When_converting_to_key_value_pair_with_no_default_values : FixtureContext
     {
-        protected static PagedZoneParameters _parameters;
+        protected static PagedDnsRecordParameters _parameters;
         protected static Dictionary<string, string> _result;
 
         Establish context = () =>
         {
             // Auto fixture chooses the default value for enumerations.
-            _fixture.Inject(PagedZoneOrderFieldTypes.email);
+            _fixture.Inject(PagedDnsRecordOrderFieldTypes.proxied);
             _fixture.Inject(PagedParametersOrderType.desc);
             _fixture.Inject(PagedParametersMatchType.any);
 
-            _parameters = _fixture.Create<PagedZoneParameters>();
+            _parameters = _fixture.Create<PagedDnsRecordParameters>();
         };
 
         Because of = () => _result = _parameters.ToKvp().ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-        Behaves_like<PagedParametersKvpBehavior<PagedZoneOrderFieldTypes>> paged_parameters_kvp_behavior;
+        Behaves_like<PagedParametersKvpBehavior<PagedDnsRecordOrderFieldTypes>> paged_parameters_kvp_behavior;
+
+        It should_have_type_value = () => _result["type"].ShouldEqual(_parameters.Type.ToString());
 
         It should_have_name_value = () => _result["name"].ShouldEqual(_parameters.Name);
 
-        It should_have_status_value = () => _result["status"].ShouldEqual(_parameters.Status.ToString());
+        It should_have_content_value = () => _result["content"].ShouldEqual(_parameters.Content);
     }
 
-    [Subject(typeof(PagedZoneParameters))]
+    [Subject(typeof(PagedDnsRecordParameters))]
     public class When_converting_to_query_string : FixtureContext
     {
-        protected static PagedZoneParameters _parameters;
+        protected static PagedDnsRecordParameters _parameters;
         protected static Dictionary<string, string> _result;
 
         Establish context = () =>
         {
             // Auto fixture chooses the default value for enumerations.
-            _fixture.Inject(PagedZoneOrderFieldTypes.email);
+            _fixture.Inject(PagedDnsRecordOrderFieldTypes.proxied);
             _fixture.Inject(PagedParametersOrderType.desc);
             _fixture.Inject(PagedParametersMatchType.any);
 
-            _parameters = _fixture.Create<PagedZoneParameters>();
+            _parameters = _fixture.Create<PagedDnsRecordParameters>();
         };
 
         Because of = () =>
@@ -138,10 +142,12 @@
             _result = kvp.Cast<string>().ToDictionary(k => k, k => kvp[k]);
         };
 
-        Behaves_like<PagedParametersKvpBehavior<PagedZoneOrderFieldTypes>> paged_parameters_kvp_behavior;
+        Behaves_like<PagedParametersKvpBehavior<PagedDnsRecordOrderFieldTypes>> paged_parameters_kvp_behavior;
+
+        It should_have_type_value = () => _result["type"].ShouldEqual(_parameters.Type.ToString());
 
         It should_have_name_value = () => _result["name"].ShouldEqual(_parameters.Name);
 
-        It should_have_status_value = () => _result["status"].ShouldEqual(_parameters.Status.ToString());
+        It should_have_content_value = () => _result["content"].ShouldEqual(_parameters.Content);
     }
 }

--- a/src/Tests/CloudFlare.NET.Tests/ZoneClientExtensionsSpec.cs
+++ b/src/Tests/CloudFlare.NET.Tests/ZoneClientExtensionsSpec.cs
@@ -14,20 +14,20 @@
     {
         static Mock<IZoneClient> _zoneClientMock;
         static CloudFlareAuth _auth;
-        static IReadOnlyList<Zone> _expected;
-        static IReadOnlyList<Zone> _actual;
+        static CloudFlareResponse<IReadOnlyList<Zone>> _expected;
+        static CloudFlareResponse<IReadOnlyList<Zone>> _actual;
 
         Establish context = () =>
         {
             _zoneClientMock = _fixture.Create<Mock<IZoneClient>>();
             _auth = _fixture.Create<CloudFlareAuth>();
-            _expected = _fixture.Create<Zone[]>();
+            _expected = _fixture.Create<CloudFlareResponse<IReadOnlyList<Zone>>>();
             _zoneClientMock
                 .Setup(c => c.GetZonesAsync(CancellationToken.None, default(PagedZoneParameters), _auth))
                 .ReturnsAsync(_expected);
         };
 
-        Because of = () => _actual = _zoneClientMock.Object.GetZonesAsync(_auth).Await().AsTask.Result;
+        Because of = () => _actual = _zoneClientMock.Object.GetZonesAsync(_auth).Await();
 
         It should_return_the_zones = () => _actual.ShouldBeTheSameAs(_expected);
     }
@@ -37,20 +37,20 @@
     {
         static Mock<IZoneClient> _zoneClientMock;
         static PagedZoneParameters _parameters;
-        static IReadOnlyList<Zone> _expected;
-        static IReadOnlyList<Zone> _actual;
+        static CloudFlareResponse<IReadOnlyList<Zone>> _expected;
+        static CloudFlareResponse<IReadOnlyList<Zone>> _actual;
 
         Establish context = () =>
         {
             _zoneClientMock = _fixture.Create<Mock<IZoneClient>>();
             _parameters = _fixture.Create<PagedZoneParameters>();
-            _expected = _fixture.Create<Zone[]>();
+            _expected = _fixture.Create<CloudFlareResponse<IReadOnlyList<Zone>>>();
             _zoneClientMock
                 .Setup(c => c.GetZonesAsync(CancellationToken.None, _parameters, default(CloudFlareAuth)))
                 .ReturnsAsync(_expected);
         };
 
-        Because of = () => _actual = _zoneClientMock.Object.GetZonesAsync(_parameters).Await().AsTask.Result;
+        Because of = () => _actual = _zoneClientMock.Object.GetZonesAsync(_parameters).Await();
 
         It should_return_the_zones = () => _actual.ShouldBeTheSameAs(_expected);
     }

--- a/src/Tests/CloudFlare.NET.Tests/ZoneClientExtensionsSpec.cs
+++ b/src/Tests/CloudFlare.NET.Tests/ZoneClientExtensionsSpec.cs
@@ -56,6 +56,52 @@
     }
 
     [Subject(typeof(ZoneClientExtensions))]
+    public class When_getting_all_zones : FixtureContext
+    {
+        static Mock<IZoneClient> _zoneClientMock;
+        static CloudFlareAuth _auth;
+        static IEnumerable<Zone> _expected;
+        static IEnumerable<Zone> _actual;
+
+        Establish context = () =>
+        {
+            _zoneClientMock = _fixture.Create<Mock<IZoneClient>>();
+            _auth = _fixture.Create<CloudFlareAuth>();
+            _expected = _fixture.CreateMany<Zone>();
+            _zoneClientMock
+                .Setup(c => c.GetAllZonesAsync(CancellationToken.None, default(PagedZoneParameters), _auth))
+                .ReturnsAsync(_expected);
+        };
+
+        Because of = () => _actual = _zoneClientMock.Object.GetAllZonesAsync(_auth).Await().AsTask.Result;
+
+        It should_return_all_the_zones = () => _actual.ShouldBeTheSameAs(_expected);
+    }
+
+    [Subject(typeof(ZoneClientExtensions))]
+    public class When_getting_all_zones_with_parameters : FixtureContext
+    {
+        static Mock<IZoneClient> _zoneClientMock;
+        static PagedZoneParameters _parameters;
+        static IEnumerable<Zone> _expected;
+        static IEnumerable<Zone> _actual;
+
+        Establish context = () =>
+        {
+            _zoneClientMock = _fixture.Create<Mock<IZoneClient>>();
+            _parameters = _fixture.Create<PagedZoneParameters>();
+            _expected = _fixture.CreateMany<Zone>();
+            _zoneClientMock
+                .Setup(c => c.GetAllZonesAsync(CancellationToken.None, _parameters, default(CloudFlareAuth)))
+                .ReturnsAsync(_expected);
+        };
+
+        Because of = () => _actual = _zoneClientMock.Object.GetAllZonesAsync(_parameters).Await().AsTask.Result;
+
+        It should_return_all_the_zones = () => _actual.ShouldBeTheSameAs(_expected);
+    }
+
+    [Subject(typeof(ZoneClientExtensions))]
     public class When_getting_a_zone : FixtureContext
     {
         static Mock<IZoneClient> _zoneClientMock;

--- a/src/Tests/CloudFlare.NET.Tests/ZoneClientExtensionsSpec.cs
+++ b/src/Tests/CloudFlare.NET.Tests/ZoneClientExtensionsSpec.cs
@@ -10,7 +10,7 @@
     using It = Machine.Specifications.It;
 
     [Subject(typeof(ZoneClientExtensions))]
-    public class When_getting_all_zones : FixtureContext
+    public class When_getting_zones : FixtureContext
     {
         static Mock<IZoneClient> _zoneClientMock;
         static CloudFlareAuth _auth;
@@ -33,7 +33,7 @@
     }
 
     [Subject(typeof(ZoneClientExtensions))]
-    public class When_getting_all_zones_with_parameters : FixtureContext
+    public class When_getting_zones_with_parameters : FixtureContext
     {
         static Mock<IZoneClient> _zoneClientMock;
         static PagedZoneParameters _parameters;

--- a/src/Tests/CloudFlare.NET.Tests/ZoneClientSpec.cs
+++ b/src/Tests/CloudFlare.NET.Tests/ZoneClientSpec.cs
@@ -8,7 +8,7 @@
     using Ploeh.AutoFixture;
 
     [Subject(typeof(CloudFlareClient))]
-    public class When_getting_all_zones : RequestContext
+    public class When_getting_zones : RequestContext
     {
         static CloudFlareResponse<IReadOnlyList<Zone>> _expected;
         static CloudFlareResponse<IReadOnlyList<Zone>> _actual;
@@ -34,7 +34,7 @@
     }
 
     [Subject(typeof(CloudFlareClient))]
-    public class When_getting_all_zones_with_parameters : RequestContext
+    public class When_getting_zones_with_parameters : RequestContext
     {
         static CloudFlareResponse<IReadOnlyList<Zone>> _expected;
         static CloudFlareResponse<IReadOnlyList<Zone>> _actual;
@@ -69,7 +69,7 @@
     }
 
     [Subject(typeof(CloudFlareClient))]
-    public class When_getting_all_zones_and_an_error_occurs : ErredRequestContext
+    public class When_getting_zones_and_an_error_occurs : ErredRequestContext
     {
         static Uri _expectedRequestUri;
 

--- a/src/Tests/CloudFlare.NET.Tests/ZoneClientSpec.cs
+++ b/src/Tests/CloudFlare.NET.Tests/ZoneClientSpec.cs
@@ -10,19 +10,18 @@
     [Subject(typeof(CloudFlareClient))]
     public class When_getting_all_zones : RequestContext
     {
-        static IReadOnlyList<Zone> _expected;
-        static IReadOnlyList<Zone> _actual;
+        static CloudFlareResponse<IReadOnlyList<Zone>> _expected;
+        static CloudFlareResponse<IReadOnlyList<Zone>> _actual;
         static Uri _expectedRequestUri;
 
         Establish context = () =>
         {
-            var response = _fixture.Create<CloudFlareResponse<IReadOnlyList<Zone>>>();
-            _expected = response.Result;
-            _handler.SetResponseContent(response);
+            _expected = _fixture.Create<CloudFlareResponse<IReadOnlyList<Zone>>>();
+            _handler.SetResponseContent(_expected);
             _expectedRequestUri = new Uri(CloudFlareConstants.BaseUri, "zones");
         };
 
-        Because of = () => _actual = _sut.GetZonesAsync(_auth).Await().AsTask.Result;
+        Because of = () => _actual = _sut.GetZonesAsync(_auth).Await();
 
         Behaves_like<AuthenticatedRequestBehaviour> authenticated_request_behaviour;
 
@@ -31,22 +30,21 @@
         It should_request_the_zones_endpoint = () => _handler.Request.RequestUri.ShouldEqual(_expectedRequestUri);
 
         It should_return_the_expected_zones = () =>
-            _actual.Select(z => z.AsLikeness().CreateProxy()).SequenceEqual(_expected).ShouldBeTrue();
+            _actual.Result.Select(z => z.AsLikeness().CreateProxy()).SequenceEqual(_expected.Result).ShouldBeTrue();
     }
 
     [Subject(typeof(CloudFlareClient))]
     public class When_getting_all_zones_with_parameters : RequestContext
     {
-        static IReadOnlyList<Zone> _expected;
-        static IReadOnlyList<Zone> _actual;
+        static CloudFlareResponse<IReadOnlyList<Zone>> _expected;
+        static CloudFlareResponse<IReadOnlyList<Zone>> _actual;
         static PagedZoneParameters _parameters;
         static Uri _expectedRequestUri;
 
         Establish context = () =>
         {
-            var response = _fixture.Create<CloudFlareResponse<IReadOnlyList<Zone>>>();
-            _expected = response.Result;
-            _handler.SetResponseContent(response);
+            _expected = _fixture.Create<CloudFlareResponse<IReadOnlyList<Zone>>>();
+            _handler.SetResponseContent(_expected);
 
             // Auto fixture chooses the default value for enumerations.
             _fixture.Inject(PagedZoneOrderFieldTypes.email);
@@ -58,7 +56,7 @@
             _expectedRequestUri = new Uri(CloudFlareConstants.BaseUri, "zones?" + _parameters.ToQuery());
         };
 
-        Because of = () => _actual = _sut.GetZonesAsync(_auth, _parameters).Await().AsTask.Result;
+        Because of = () => _actual = _sut.GetZonesAsync(_auth, _parameters).Await();
 
         Behaves_like<AuthenticatedRequestBehaviour> authenticated_request_behaviour;
 
@@ -67,7 +65,7 @@
         It should_request_the_zones_endpoint = () => _handler.Request.RequestUri.ShouldEqual(_expectedRequestUri);
 
         It should_return_the_expected_zones = () =>
-            _actual.Select(z => z.AsLikeness().CreateProxy()).SequenceEqual(_expected).ShouldBeTrue();
+            _actual.Result.Select(z => z.AsLikeness().CreateProxy()).SequenceEqual(_expected.Result).ShouldBeTrue();
     }
 
     [Subject(typeof(CloudFlareClient))]

--- a/src/Tests/CloudFlare.NET.Tests/ZoneClientSpec.cs
+++ b/src/Tests/CloudFlare.NET.Tests/ZoneClientSpec.cs
@@ -4,7 +4,9 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
+    using System.Threading;
     using Machine.Specifications;
+    using Newtonsoft.Json.Linq;
     using Ploeh.AutoFixture;
 
     [Subject(typeof(CloudFlareClient))]
@@ -66,6 +68,92 @@
 
         It should_return_the_expected_zones = () =>
             _actual.Result.Select(z => z.AsLikeness().CreateProxy()).SequenceEqual(_expected.Result).ShouldBeTrue();
+    }
+
+    [Subject(typeof(CloudFlareClient))]
+    public class When_getting_all_zones : GetAllResultsContext<Zone>
+    {
+        static Uri _expectedFirstRequestUri;
+        static Uri _expectedSecondRequestUri;
+        static Uri _expectedLastRequestUri;
+
+        Establish context = () =>
+        {
+            string firstParams = new PagedZoneParameters(page: 1, perPage: 100).ToQuery();
+            string secondParams = new PagedZoneParameters(page: 2, perPage: 100).ToQuery();
+            string lastParams = new PagedZoneParameters(page: 3, perPage: 100).ToQuery();
+
+            _expectedFirstRequestUri = new Uri(CloudFlareConstants.BaseUri, "zones?" + firstParams);
+            _expectedSecondRequestUri = new Uri(CloudFlareConstants.BaseUri, "zones?" + secondParams);
+            _expectedLastRequestUri = new Uri(CloudFlareConstants.BaseUri, "zones?" + lastParams);
+        };
+
+        Because of = () => _actual = _sut.GetAllZonesAsync(_auth).Await().AsTask.Result;
+
+        Behaves_like<AuthenticatedRequestBehaviour> authenticated_request_behaviour;
+
+        It should_make_a_GET_request = () => _handler.Request.Method.ShouldEqual(HttpMethod.Get);
+
+        It should_request_the_first_page = () => _handler.Requests[0].RequestUri.ShouldEqual(_expectedFirstRequestUri);
+
+        It should_request_the_second_page =
+            () => _handler.Requests[1].RequestUri.ShouldEqual(_expectedSecondRequestUri);
+
+        It should_request_the_last_page = () => _handler.Requests[2].RequestUri.ShouldEqual(_expectedLastRequestUri);
+
+        It should_return_the_expected_zones = () =>
+            _actual.Select(z => z.AsLikeness().CreateProxy()).SequenceEqual(_expected).ShouldBeTrue();
+    }
+
+    [Subject(typeof(CloudFlareClient))]
+    public class When_getting_all_zones_with_parameters : GetAllResultsContext<Zone>
+    {
+        static PagedZoneParameters _parameters;
+        static Uri _expectedFirstRequestUri;
+        static Uri _expectedSecondRequestUri;
+        static Uri _expectedLastRequestUri;
+
+        Establish context = () =>
+        {
+            // Auto fixture chooses the default value for enumerations.
+            _fixture.Inject(PagedZoneOrderFieldTypes.email);
+            _fixture.Inject(PagedParametersOrderType.desc);
+            _fixture.Inject(PagedParametersMatchType.any);
+
+            _parameters = _fixture.Create<PagedZoneParameters>();
+
+            JObject first = JObject.FromObject(_parameters);
+            first.Merge(JObject.FromObject(new { page = 1, per_page = 100 }));
+            string firstParams = first.ToObject<PagedZoneParameters>().ToQuery();
+
+            JObject second = JObject.FromObject(_parameters);
+            second.Merge(JObject.FromObject(new { page = 2, per_page = 100 }));
+            string secondParams = second.ToObject<PagedZoneParameters>().ToQuery();
+
+            JObject last = JObject.FromObject(_parameters);
+            last.Merge(JObject.FromObject(new { page = 3, per_page = 100 }));
+            string lastParams = last.ToObject<PagedZoneParameters>().ToQuery();
+
+            _expectedFirstRequestUri = new Uri(CloudFlareConstants.BaseUri, "zones?" + firstParams);
+            _expectedSecondRequestUri  = new Uri(CloudFlareConstants.BaseUri, "zones?" + secondParams);
+            _expectedLastRequestUri = new Uri(CloudFlareConstants.BaseUri, "zones?" + lastParams);
+        };
+
+        Because of = () => _actual = _sut.GetAllZonesAsync(_auth, _parameters).Await().AsTask.Result;
+
+        Behaves_like<AuthenticatedRequestBehaviour> authenticated_request_behaviour;
+
+        It should_make_a_GET_request = () => _handler.Request.Method.ShouldEqual(HttpMethod.Get);
+
+        It should_request_the_first_page = () => _handler.Requests[0].RequestUri.ShouldEqual(_expectedFirstRequestUri);
+
+        It should_request_the_second_page =
+            () => _handler.Requests[1].RequestUri.ShouldEqual(_expectedSecondRequestUri);
+
+        It should_request_the_last_page = () => _handler.Requests[2].RequestUri.ShouldEqual(_expectedLastRequestUri);
+
+        It should_return_the_expected_zones = () =>
+            _actual.Select(z => z.AsLikeness().CreateProxy()).SequenceEqual(_expected).ShouldBeTrue();
     }
 
     [Subject(typeof(CloudFlareClient))]

--- a/src/Tests/CloudFlare.NET.Tests/packages.config
+++ b/src/Tests/CloudFlare.NET.Tests/packages.config
@@ -16,7 +16,7 @@
   <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="OpenCover" version="4.6.166" targetFramework="net45" />
-  <package id="ReportGenerator" version="2.2.0.0" targetFramework="net45" />
+  <package id="ReportGenerator" version="2.3.0.0" targetFramework="net45" />
   <package id="SemanticComparison" version="3.31.0" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />

--- a/src/Tests/CloudFlare.NET.Yaml.Tests/CloudFlareClientExtensionsSpec.cs
+++ b/src/Tests/CloudFlare.NET.Yaml.Tests/CloudFlareClientExtensionsSpec.cs
@@ -21,26 +21,25 @@
         Establish context = () =>
         {
             _expectedZone = _fixture.Create<Zone>();
-            var dnsRecordsResponse = _fixture.Create<CloudFlareResponse<IReadOnlyList<DnsRecord>>>();
-            _expectedDnsRecords = dnsRecordsResponse.Result;
+            _expectedDnsRecords = _fixture.CreateMany<DnsRecord>().ToArray();
             _auth = _fixture.Create<CloudFlareAuth>();
             _clientMock = _fixture.Create<Mock<ICloudFlareClient>>();
 
             _clientMock.Setup(c => c.GetZoneAsync(_expectedZone.Id, CancellationToken.None, _auth))
                 .ReturnsAsync(_expectedZone);
             _clientMock.Setup(
-                c => c.GetDnsRecordsAsync(
+                c => c.GetAllDnsRecordsAsync(
                     _expectedZone.Id,
                     CancellationToken.None,
                     default(PagedDnsRecordParameters),
                     _auth))
-                .ReturnsAsync(dnsRecordsResponse);
+                .ReturnsAsync(_expectedDnsRecords);
         };
 
         Because of = () => _actual = _clientMock.Object.GetZoneDataAsync(_expectedZone.Id, _auth).Await();
 
         It should_get_the_zone = () => _actual.Zone.ShouldBeTheSameAs(_expectedZone);
 
-        It should_get_the_DNS_records = () => _actual.DnsRecords.ShouldBeTheSameAs(_expectedDnsRecords);
+        It should_get_all_the_DNS_records = () => _actual.DnsRecords.SequenceEqual(_expectedDnsRecords).ShouldBeTrue();
     }
 }

--- a/src/Tests/CloudFlare.NET.Yaml.Tests/CloudFlareClientExtensionsSpec.cs
+++ b/src/Tests/CloudFlare.NET.Yaml.Tests/CloudFlareClientExtensionsSpec.cs
@@ -25,7 +25,12 @@
 
             _clientMock.Setup(c => c.GetZoneAsync(_expected.Zone.Id, CancellationToken.None, _auth))
                 .ReturnsAsync(_expected.Zone);
-            _clientMock.Setup(c => c.GetDnsRecordsAsync(_expected.Zone.Id, CancellationToken.None, _auth))
+            _clientMock.Setup(
+                c => c.GetDnsRecordsAsync(
+                    _expected.Zone.Id,
+                    CancellationToken.None,
+                    default(PagedDnsRecordParameters),
+                    _auth))
                 .ReturnsAsync(_expected.DnsRecords);
         };
 

--- a/src/Tests/CloudFlare.NET.Yaml.Tests/CloudFlareClientExtensionsSpec.cs
+++ b/src/Tests/CloudFlare.NET.Yaml.Tests/CloudFlareClientExtensionsSpec.cs
@@ -12,32 +12,35 @@
 
     public class When_getting_all_the_zone_data : FixtureContext
     {
-        static ZoneData _expected;
+        static Zone _expectedZone;
+        static IReadOnlyList<DnsRecord> _expectedDnsRecords;
         static ZoneData _actual;
         static CloudFlareAuth _auth;
         static Mock<ICloudFlareClient> _clientMock;
 
         Establish context = () =>
         {
-            _expected = _fixture.Create<ZoneData>();
+            _expectedZone = _fixture.Create<Zone>();
+            var dnsRecordsResponse = _fixture.Create<CloudFlareResponse<IReadOnlyList<DnsRecord>>>();
+            _expectedDnsRecords = dnsRecordsResponse.Result;
             _auth = _fixture.Create<CloudFlareAuth>();
             _clientMock = _fixture.Create<Mock<ICloudFlareClient>>();
 
-            _clientMock.Setup(c => c.GetZoneAsync(_expected.Zone.Id, CancellationToken.None, _auth))
-                .ReturnsAsync(_expected.Zone);
+            _clientMock.Setup(c => c.GetZoneAsync(_expectedZone.Id, CancellationToken.None, _auth))
+                .ReturnsAsync(_expectedZone);
             _clientMock.Setup(
                 c => c.GetDnsRecordsAsync(
-                    _expected.Zone.Id,
+                    _expectedZone.Id,
                     CancellationToken.None,
                     default(PagedDnsRecordParameters),
                     _auth))
-                .ReturnsAsync(_expected.DnsRecords);
+                .ReturnsAsync(dnsRecordsResponse);
         };
 
-        Because of = () => _actual = _clientMock.Object.GetZoneDataAsync(_expected.Zone.Id, _auth).Await();
+        Because of = () => _actual = _clientMock.Object.GetZoneDataAsync(_expectedZone.Id, _auth).Await();
 
-        It should_get_the_zone = () => _actual.Zone.ShouldBeTheSameAs(_expected.Zone);
+        It should_get_the_zone = () => _actual.Zone.ShouldBeTheSameAs(_expectedZone);
 
-        It should_get_the_DNS_records = () => _actual.DnsRecords.ShouldBeTheSameAs(_expected.DnsRecords);
+        It should_get_the_DNS_records = () => _actual.DnsRecords.ShouldBeTheSameAs(_expectedDnsRecords);
     }
 }

--- a/src/Tests/CloudFlare.NET.Yaml.Tests/CloudFlareCustomization.cs
+++ b/src/Tests/CloudFlare.NET.Yaml.Tests/CloudFlareCustomization.cs
@@ -21,8 +21,9 @@
         {
             fixture.Register(() => new IdentifierTag(Guid.NewGuid().ToString("N")));
             fixture.Register<IReadOnlyList<string>>(fixture.Create<string[]>);
-            fixture.Register<IReadOnlyList<DnsRecord>>(fixture.Create<DnsRecord[]>);
             fixture.Register<IReadOnlyList<CloudFlareError>>(fixture.Create<CloudFlareError[]>);
+            fixture.Register<IReadOnlyList<Zone>>(fixture.Create<Zone[]>);
+            fixture.Register<IReadOnlyList<DnsRecord>>(fixture.Create<DnsRecord[]>);
             fixture.Register(() => JObject.FromObject(fixture.Create<CloudFlareResponseBase>()));
         }
     }


### PR DESCRIPTION
Methods like [List zones](https://api.cloudflare.com/#zone-list-zones) and [List DNS Records](https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records) have a maximum number of entries they will return in a single request, and use paging to return more records.

To handle this the library now exposes the paged results in the API, which has resulted in breaking change.

Helper methods `GetAll[Zones|DnsRecords]Async` are also provided that still return the complete list and will make multiple requests if necessary.
